### PR TITLE
ユーザー一覧画面の実装

### DIFF
--- a/src/main/java/com/example/demo/controller/HomeController.java
+++ b/src/main/java/com/example/demo/controller/HomeController.java
@@ -1,14 +1,36 @@
 package com.example.demo.controller;
 
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Controller;
+import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.RequestMapping;
 
+import com.example.demo.model.User;
+import com.example.demo.service.UserService;
+
+import lombok.RequiredArgsConstructor;
+
 @Controller
+@RequiredArgsConstructor
 public class HomeController {
+	
+	//以下のクラスをインスタンス化
+	@Autowired
+	private final UserService userService;
 	
 	//Top画面の処理
 	@RequestMapping("/top")
-	private String top() {
+	private String top(Model model) {
+		
+		//sessionからuserIdを取得
+		Authentication auth = SecurityContextHolder.getContext().getAuthentication();
+		int userId = Integer.parseInt(auth.getName());
+		//userIdをもとにuserデータを取得
+		User user = userService.findById(userId);
+		//変数をモデルに登録
+		model.addAttribute("user", user);
 		//top画面に遷移
 		return "top";
 	}

--- a/src/main/java/com/example/demo/controller/UserController.java
+++ b/src/main/java/com/example/demo/controller/UserController.java
@@ -1,8 +1,15 @@
 package com.example.demo.controller;
 
+import java.util.ArrayList;
+
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Controller;
+import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
+
+import com.example.demo.model.User;
+import com.example.demo.service.UserService;
 
 import lombok.RequiredArgsConstructor;
 
@@ -10,6 +17,10 @@ import lombok.RequiredArgsConstructor;
 @Controller
 @RequiredArgsConstructor
 public class UserController {
+	
+	//以下のクラスをインスタンス化
+	@Autowired
+	private final UserService userService;
 	
 	//ログイン画面の処理
 	@GetMapping("/login")
@@ -23,5 +34,15 @@ public class UserController {
 	public String getLogout() {
 		//login画面に遷移
 		return "login";
+	}
+	
+	//一覧画面の処理
+	@GetMapping("/user/lists")
+	public String getList(Model model) {
+		//全てのユーザーを取得
+		ArrayList<User> userList = userService.findAll();
+		//変数をモデルに登録
+		model.addAttribute("userList", userList);
+		return "user_lists";
 	}
 }

--- a/src/main/java/com/example/demo/model/User.java
+++ b/src/main/java/com/example/demo/model/User.java
@@ -29,6 +29,8 @@ public class User implements UserDetails {
 	
 	private Timestamp deleted_at;
 	
+	private int admin_flag;
+	
 	//権限を取得
 	@Override
 	public Collection<? extends GrantedAuthority> getAuthorities() {

--- a/src/main/java/com/example/demo/repository/UserMapper.java
+++ b/src/main/java/com/example/demo/repository/UserMapper.java
@@ -1,5 +1,7 @@
 package com.example.demo.repository;
 
+import java.util.ArrayList;
+
 import org.apache.ibatis.annotations.Mapper;
 
 import com.example.demo.model.User;
@@ -8,4 +10,7 @@ import com.example.demo.model.User;
 public interface UserMapper {
 	//userIdをもとにユーザーを取得
 	User findById(int userId);
+	
+	//ユーザーをすべて取得
+	ArrayList<User> findAll();
 }

--- a/src/main/java/com/example/demo/service/UserService.java
+++ b/src/main/java/com/example/demo/service/UserService.java
@@ -1,5 +1,7 @@
 package com.example.demo.service;
 
+import java.util.ArrayList;
+
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.security.core.userdetails.UserDetailsService;
@@ -44,5 +46,11 @@ public class UserService implements UserDetailsService {
 	@Transactional
 	public User findById(int userId) {
 		return userMapper.findById(userId);
+	}
+	
+	//ユーザーを全て取得
+	@Transactional
+	public ArrayList<User> findAll() {
+		return userMapper.findAll();
 	}
 }

--- a/src/main/resources/com/example/demo/repository/UserMapper.xml
+++ b/src/main/resources/com/example/demo/repository/UserMapper.xml
@@ -4,4 +4,7 @@
 	<select id="findById" resultType="com.example.demo.model.User">
 		SELECT * FROM users WHERE id = #{userId};
 	</select>
+	<select id="findAll" resultType="com.example.demo.model.User">
+		SELECT * FROM users;
+	</select>
 </mapper>

--- a/src/main/resources/static/css/style.css
+++ b/src/main/resources/static/css/style.css
@@ -325,17 +325,55 @@ h2 {
 }
 
 /* History画面のtableタグ*/
-table {
+.history_table {
 	/* 票の枠線を重ねる*/
 	border-collapse: collapse;
 }
 
 /* History画面のtd, thタグ*/
-td, th {
+.history_table td, th {
 	/*余白を7px作る*/
 	padding: 7px;
 	/*幅を210pxにする*/
 	width: 210px;
 	/*枠線の太さを1pxにして、1本線にする*/
 	border: solid 1px;
+}
+
+/* History画面のtd, thタグ*/
+.user_table td, th {
+	/*余白を2px作る*/
+	padding: 2px;
+	/*境界線をなくす*/
+	border: none;
+	/*文字を左詰めにする*/
+	text-align: left;
+}
+
+/* user_lists画面のtd, thタグのuser_id_areaクラス*/
+.user_id_area {
+	/*幅を全体の10%にする*/
+	width: 10%;
+}
+
+/* user_lists画面のtd, thタグのuser_auth_areaクラス*/
+.user_auth_area {
+	/*幅を全体の10%にする*/
+	width: 10%;	
+}
+
+/* user_lists画面のtd, thタグのuser_name_areaクラス*/
+.user_name_area {
+	/*幅を全体の63.5%にする*/
+	width: 65.3%;
+}
+
+/* user_lists画面の新規作成ボタン*/
+.user_new_btn {
+	/* 要素を右寄せする */
+	margin-left: auto;
+	/* 上に余白を10pxつくる*/
+	margin-top: 10px;
+	/* 要素をブロック化する*/
+	display: block;
 }

--- a/src/main/resources/templates/history.html
+++ b/src/main/resources/templates/history.html
@@ -19,7 +19,7 @@
 		</th:block>
 		<!--履歴が登録されている場合  -->
 		<th:block th:if="${!hisList.isEmpty()}">
-			<table>
+			<table class="history_table">
 				 <tr>
 				 	<th>氏名</th>
 				 	<th>得点</th>

--- a/src/main/resources/templates/list.html
+++ b/src/main/resources/templates/list.html
@@ -23,8 +23,8 @@
 				<!-- 問題に紐づく答えの数だけ処理を繰り返す  -->
 				<div class="list_answers_area" th:each="ans, ansStatus:${ansList.get(queStatus.index)}">
 					<p th:text="'答え' + ${ansStatus.count} + ' ' + ${ans.getAnswer()}"></p>
-					</div>
 				</div>
+			</div>
 			<div>
 				<a th:href="@{/edit/{id}(id=${que.getId()})}"><button>編集</button></a>
 				<a th:href="@{/delete_confirm/{id}(id=${que.getId()})}"><button>削除</button></a>

--- a/src/main/resources/templates/top.html
+++ b/src/main/resources/templates/top.html
@@ -6,17 +6,18 @@
 	<link rel="stylesheet" media="all" th:href="@{/css/style.css}"/>
 </head>
 <body>
-	<h2 th:text ="${userName}"></h2>
 	<div class="btn_area">
 		<form th:action="@{/logout}" method="post">
 			<input type="submit" value="logout" class="logout_btn">
 		</form>
 	</div>
 	<div class="menu_area">
-		<button onclick="location.href='./list'">問題と答えを確認・登録する ></button>
+		<!-- 問題/答え登録・確認ボタンは管理者のみ表示 -->
+		<button th:if="${user.getAdmin_flag == 1}" onclick="location.href='./list'">問題と答えを確認・登録する ></button>
 		<button onclick="location.href='./test'">テストをする ></button>
 		<button onclick="location.href='./history'">過去の採点結果をみる ></button>
-		<button onclick="location.href='./user/lists'">ユーザーを追加・編集する ></button>
+		<!-- ユーザー追加・編集ボタンは管理者のみ表示 -->
+		<button th:if="${user.getAdmin_flag == 1}" onclick="location.href='./user/lists'">ユーザーを追加・編集する ></button>
 	</div>
 </body>
 </html>

--- a/src/main/resources/templates/top.html
+++ b/src/main/resources/templates/top.html
@@ -16,6 +16,7 @@
 		<button onclick="location.href='./list'">問題と答えを確認・登録する ></button>
 		<button onclick="location.href='./test'">テストをする ></button>
 		<button onclick="location.href='./history'">過去の採点結果をみる ></button>
+		<button onclick="location.href='./user/lists'">ユーザーを追加・編集する ></button>
 	</div>
 </body>
 </html>

--- a/src/main/resources/templates/user_lists.html
+++ b/src/main/resources/templates/user_lists.html
@@ -19,7 +19,7 @@
 				<th class="user_auth_area">権限</th>
 				<th class="user_name_area">ユーザー名</th>
 			</tr>
-			<!-- 問題の数だけ処理を繰り返す  -->
+			<!-- ユーザーの数だけ処理を繰り返す  -->
 			<th:block th:each="user : ${userList}">
 				<tr>
 					<td class="user_id_area" th:text="${user.getId()}" ></td>

--- a/src/main/resources/templates/user_lists.html
+++ b/src/main/resources/templates/user_lists.html
@@ -12,21 +12,24 @@
 				<input type="submit" value="logout" class="logout_btn">
 			</form>
 		</div>
-		<button class="new_btn" onclick="location.href='./register'" >新規登録</button>
-		<table>
+		<button class="user_new_btn" onclick="location.href='./register'" >新規登録</button>
+		<table class="user_table">
 			<tr>
-				<th>ID</th>
-				<th>権限</th>
-				<th>ユーザー名</th>
+				<th class="user_id_area">ID</th>
+				<th class="user_auth_area">権限</th>
+				<th class="user_name_area">ユーザー名</th>
 			</tr>
 			<!-- 問題の数だけ処理を繰り返す  -->
 			<th:block th:each="user : ${userList}">
 				<tr>
-					<td th:text="${user.getId()}" ></td>
-					<td th:text="${user.getAdmin_flag()}" ></td>
-					<td th:text="${user.getName()}" ></td>
+					<td class="user_id_area" th:text="${user.getId()}" ></td>
+					<td class="user_auth_area" th:if="${user.getAdmin_flag() == 0}">一般</td>
+					<td class="user_auth_area" th:if="${user.getAdmin_flag() == 1}">管理者</td>
+					<td class="user_name_area" th:text="${user.getName()}" ></td>
 					<td>
 						<a th:href="@{/user/{id}(id=${user.getId()})}"><button>編集</button></a>
+					</td>
+					<td>
 						<a th:href="@{/user/{id}(id=${user.getId()})}"><button>削除</button></a>
 					</td>
 				</tr>

--- a/src/main/resources/templates/user_lists.html
+++ b/src/main/resources/templates/user_lists.html
@@ -1,0 +1,36 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="UTF-8">
+<title>user_lists</title>
+<link rel="stylesheet" media="all" th:href="@{/css/style.css}"/>
+</head>
+	<body>
+		<div class="btn_area">
+			<button onclick="location.href='../top'">top</button>
+			<form th:action="@{/logout}" method="post">
+				<input type="submit" value="logout" class="logout_btn">
+			</form>
+		</div>
+		<button class="new_btn" onclick="location.href='./register'" >新規登録</button>
+		<table>
+			<tr>
+				<th>ID</th>
+				<th>権限</th>
+				<th>ユーザー名</th>
+			</tr>
+			<!-- 問題の数だけ処理を繰り返す  -->
+			<th:block th:each="user : ${userList}">
+				<tr>
+					<td th:text="${user.getId()}" ></td>
+					<td th:text="${user.getAdmin_flag()}" ></td>
+					<td th:text="${user.getName()}" ></td>
+					<td>
+						<a th:href="@{/user/{id}(id=${user.getId()})}"><button>編集</button></a>
+						<a th:href="@{/user/{id}(id=${user.getId()})}"><button>削除</button></a>
+					</td>
+				</tr>
+			</th:block>
+		</table>
+	</body>
+</html>


### PR DESCRIPTION
<top画面>
homeコントローラーのtopメソッドにおいて、セッションからuser_idを取得し、user_idからユーザー情報を取得して、top.htmlに渡す。top.htmlでは「問題と答えを確認・登録する」ボタンと「ユーザーを追加・編集する」ボタンは、ログインしているユーザーが管理者だった場合のみ、表示させるようにする。

<user_lists画面>
・DBに登録されているユーザーの情報（id, auth, name）と各ユーザーごとに編集ボタン、削除ボタンを表示。
・topボタンとloginボタン、新規登録ボタンを設置