### PR TITLE
単体テストを追加、実装済みの機能を一部修正

### DIFF
--- a/src/main/java/com/example/demo/controller/UserController.java
+++ b/src/main/java/com/example/demo/controller/UserController.java
@@ -153,10 +153,12 @@ public class UserController {
 		//userIdからadminFlagを取得
 		User currentUser = userService.findById(currentUserId);
 		int currentUserAdminFlag = currentUser.getAdmin_flag();
+		//ログインユーザーが自身の管理者権限を無効にした場合
 		if(currentUserId == userId && currentUserAdminFlag == 0) {
 			//権限情報を更新し、セッションに設定
 			Authentication newAuth = new UsernamePasswordAuthenticationToken(auth.getPrincipal(), auth.getCredentials(), AuthorityUtils.createAuthorityList("USER"));
 			SecurityContextHolder.getContext().setAuthentication(newAuth);
+			//top画面にリダイレクト
 			return "redirect:/top";
 		} else {
 			//user_lists画面にリダイレクト

--- a/src/main/java/com/example/demo/controller/UserController.java
+++ b/src/main/java/com/example/demo/controller/UserController.java
@@ -43,13 +43,6 @@ public class UserController {
 		return "login";
 	}
 	
-	//ログアウトの処理
-	@PostMapping("/logout")
-	public String postLogout() {
-		//login画面に遷移
-		return "login";
-	}
-	
 	//ユーザー一覧画面の処理
 	@GetMapping("/user/lists")
 	public String getList(Model model) {
@@ -161,7 +154,7 @@ public class UserController {
 		User currentUser = userService.findById(currentUserId);
 		int currentUserAdminFlag = currentUser.getAdmin_flag();
 		if(currentUserId == userId && currentUserAdminFlag == 0) {
-			//トークンに保存されている権限情報を更新し、セッションに設定
+			//権限情報を更新し、セッションに設定
 			Authentication newAuth = new UsernamePasswordAuthenticationToken(auth.getPrincipal(), auth.getCredentials(), AuthorityUtils.createAuthorityList("USER"));
 			SecurityContextHolder.getContext().setAuthentication(newAuth);
 			return "redirect:/top";

--- a/src/main/java/com/example/demo/security/SecurityConfig.java
+++ b/src/main/java/com/example/demo/security/SecurityConfig.java
@@ -7,7 +7,6 @@ import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
-import org.springframework.security.web.savedrequest.HttpSessionRequestCache;
 
 
 @Configuration
@@ -16,16 +15,13 @@ public class SecurityConfig {
 	
 	@Bean
 	public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
-		//パフォーマンスの最適化機能を無効にする
-	    HttpSessionRequestCache requestCache = new HttpSessionRequestCache();
-	    requestCache.setMatchingRequestParameterName(null);
 		http
 			.authorizeHttpRequests((authorize) -> authorize
 				// アクセス制限をかけない要求
 				.requestMatchers("/favicon.ico", "/resources/**", "/error").permitAll()
 				.requestMatchers(PathRequest.toStaticResources().atCommonLocations()).permitAll()
 				// 管理者しかアクセスできないページを設定
-				.requestMatchers("/user/*", "/user/edit/*").hasAuthority("ADMIN")
+				.requestMatchers("/user/*", "/user/edit/*", "/user/delete/*/confirm").hasAuthority("ADMIN")
 				//上記以外のすべての要求で、ユーザーの認証を必要とする
 				.anyRequest().authenticated()
 			)
@@ -44,9 +40,7 @@ public class SecurityConfig {
 				.logoutUrl("/logout")
 				// ログアウトした場合の遷移先
 				.logoutSuccessUrl("/login").permitAll()
-			)
-			.requestCache((cache) -> cache
-				.requestCache(requestCache));
+			);
 		return http.build();
 	}
 	

--- a/src/main/java/com/example/demo/security/SecurityConfig.java
+++ b/src/main/java/com/example/demo/security/SecurityConfig.java
@@ -21,7 +21,7 @@ public class SecurityConfig {
 				.requestMatchers("/favicon.ico", "/resources/**", "/error").permitAll()
 				.requestMatchers(PathRequest.toStaticResources().atCommonLocations()).permitAll()
 				// 管理者しかアクセスできないページを設定
-				.requestMatchers("/user/*", "/user/edit/*", "/user/delete/*/confirm").hasAuthority("ADMIN")
+				.requestMatchers("/list", "/register", "/delete_confirm/*", "/edit/*", "/user/*", "/user/edit/*", "/user/delete/*/confirm").hasAuthority("ADMIN")
 				//上記以外のすべての要求で、ユーザーの認証を必要とする
 				.anyRequest().authenticated()
 			)

--- a/src/main/resources/com/example/demo/repository/HistoryMapper.xml
+++ b/src/main/resources/com/example/demo/repository/HistoryMapper.xml
@@ -2,7 +2,7 @@
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
 <mapper namespace="com.example.demo.repository.HistoryMapper">
 	<select id="findByUserId" resultType="com.example.demo.model.History">
-		SELECT * FROM histories WHERE user_id = #{userId} ORDER BY created_at;
+		SELECT * FROM histories WHERE user_id = #{userId} AND deleted_at IS NULL ORDER BY created_at;
 	</select>
 	<insert id="register">
 		INSERT INTO histories (user_id, point, created_at) VALUES (#{userId}, #{point}, CURRENT_TIMESTAMP());

--- a/src/main/resources/templates/common/header.html
+++ b/src/main/resources/templates/common/header.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <div class="btn_area" th:fragment="header">
+	<button onclick="location.href='/top'">top</button>
+	<form th:action="@{/logout}" method="post">
+		<input type="submit" value="logout" class="logout_btn">
+	</form>
+</div>
+</html>

--- a/src/main/resources/templates/confirm.html
+++ b/src/main/resources/templates/confirm.html
@@ -6,16 +6,11 @@
 		<link rel="stylesheet" media="all" th:href="@{/css/style.css}"/>
 	</head>
 	<body>
-		<div class="btn_area">
-			<button onclick="location.href='../top'">top</button>
-			<form th:action="@{/logout}" method="post">
-				<input type="submit" value="logout" class="logout_btn">
-			</form>
-		</div>
+		<div th:replace="common/header::header"></div>
 		<!-- formタグで入力されたデータを./register/completeにpostで送信  -->
 		<form th:action="@{/register/complete}" method="post">
 			<!-- エラーメッセージがある場合  -->
-			<th:block th:if="${!errorMessage.isEmpty()}">
+			<th:bloc k th:if="${!errorMessage.isEmpty()}">
 				<p class="error" th:utext="${errorMessage}"></p>
 			</th:block>
 			<div class="question_area">

--- a/src/main/resources/templates/delete_confirm.html
+++ b/src/main/resources/templates/delete_confirm.html
@@ -6,12 +6,7 @@
 		<link rel="stylesheet" media="all" th:href="@{/css/style.css}"/>
 	</head>
 	<body>
-		<div class="btn_area">
-			<button onclick="location.href='../top'">top</button>
-			<form th:action="@{/logout}" method="post">
-				<input type="submit" value="logout" class="logout_btn">
-			</form>
-		</div>
+		<div th:replace="common/header::header"></div>
 		<!-- formタグで入力されたデータを/delete/completeにpostで送信  -->
 		<form th:action="@{/delete/complete}" method="post">
 			<div class="question_area">

--- a/src/main/resources/templates/edit.html
+++ b/src/main/resources/templates/edit.html
@@ -23,12 +23,7 @@
 		<script type="text/javascript" th:src="@{/js/delete_answer_form.js}"></script>
 	</head>
 	<body>
-		<div class="btn_area">
-			<button onclick="location.href='../top'">top</button>
-			<form th:action="@{/logout}" method="post">
-				<input type="submit" value="logout" class="logout_btn">
-			</form>
-		</div>
+		<div th:replace="common/header::header"></div>
 		<!-- formタグで入力されたデータを/edit/confirmにpostで送信する  -->
 		<form th:action="@{/edit/confirm}" method="post">
 			<div class="question_id_area">

--- a/src/main/resources/templates/edit_confirm.html
+++ b/src/main/resources/templates/edit_confirm.html
@@ -6,12 +6,7 @@
 		<link rel="stylesheet" media="all" th:href="@{/css/style.css}"/>
 	</head>
 	<body>
-		<div class="btn_area">
-			<button onclick="location.href='../top'">top</button>
-			<form th:action="@{/logout}" method="post">
-				<input type="submit" value="logout" class="logout_btn">
-			</form>
-		</div>
+		<div th:replace="common/header::header"></div>
 		<!-- formタグで入力されたデータを/edit/completeにpostで送信する  -->
 		<form th:action="@{/edit/complete}" method="post">
 			<!-- エラーメッセージがある場合  -->

--- a/src/main/resources/templates/error.html
+++ b/src/main/resources/templates/error.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org">
+  <head>
+    <meta charset="UTF-8">
+    <title>errorページ</title>
+  </head>
+  <body>
+    <h1>errorページ</h1>
+    <p>アクセス権限が不足しているか、URLが正しく入力されていません</p>
+    <a href="/top">topに戻る</a>
+  </body>
+</html>

--- a/src/main/resources/templates/error.html
+++ b/src/main/resources/templates/error.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html xmlns:th="http://www.thymeleaf.org">
+<html>
   <head>
     <meta charset="UTF-8">
     <title>errorページ</title>

--- a/src/main/resources/templates/history.html
+++ b/src/main/resources/templates/history.html
@@ -6,12 +6,7 @@
 		<link rel="stylesheet" media="all" th:href="@{/css/style.css}"/>
 	</head>
 	<body>
-		<div class="btn_area">
-			<button onclick="location.href='./top'">top</button>
-			<form th:action="@{/logout}" method="post">
-				<input type="submit" value="logout" class="logout_btn">
-			</form>
-		</div>
+		<div th:replace="common/header::header"></div>
 		<h2>履歴</h2>
 		<!--履歴が登録されていない場合  -->
 		<th:block th:if="${hisList.isEmpty()}">

--- a/src/main/resources/templates/list.html
+++ b/src/main/resources/templates/list.html
@@ -1,17 +1,12 @@
 <!DOCTYPE html>
 <html>
-<head>
-<meta charset="UTF-8">
-<title>List</title>
-<link rel="stylesheet" media="all" th:href="@{/css/style.css}"/>
-</head>
+	<head>
+		<meta charset="UTF-8">
+		<title>List</title>
+		<link rel="stylesheet" media="all" th:href="@{/css/style.css}"/>
+	</head>
 	<body>
-		<div class="btn_area">
-			<button onclick="location.href='./top'">top</button>
-			<form th:action="@{/logout}" method="post">
-				<input type="submit" value="logout" class="logout_btn">
-			</form>
-		</div>
+		<div th:replace="common/header::header"></div>
 		<button class="new_btn" onclick="location.href='./register'" >新規登録</button>
 		<!-- 問題の数だけ処理を繰り返す  -->
 		<div class="list_area" th:each="que, queStatus:${queList}">

--- a/src/main/resources/templates/login.html
+++ b/src/main/resources/templates/login.html
@@ -1,9 +1,9 @@
 <!DOCTYPE html>
 <html>
 	<head>
-	<meta charset="UTF-8">
-	<title>Login</title>
-	<link rel="stylesheet" media="all" th:href="@{/css/style.css}"/>
+		<meta charset="UTF-8">
+		<title>Login</title>
+		<link rel="stylesheet" media="all" th:href="@{/css/style.css}"/>
 	</head>
 	<body>
 	 	<!-- formタグで入力されたデータを./Loginにpostで送信する  -->

--- a/src/main/resources/templates/register.html
+++ b/src/main/resources/templates/register.html
@@ -25,12 +25,7 @@
 	</head>
 	
 	<body>
-		<div class="btn_area">
-			<button onclick="location.href='./top'">top</button>
-			<form th:action="@{/logout}" method="post">
-				<input type="submit" value="logout" class="logout_btn">
-			</form>
-		</div>
+		<div th:replace="common/header::header"></div>
 		<!-- formタグで入力されたデータを/register/confirmにpostで送信する  -->
 		<form th:action="@{/register/confirm}" method="post">
 			<div class="question_form_area">

--- a/src/main/resources/templates/result.html
+++ b/src/main/resources/templates/result.html
@@ -6,12 +6,7 @@
 		<link rel="stylesheet" media="all" th:href="@{/css/style.css}"/>
 	</head>
 	<body>
-		<div class="btn_area">
-			<button onclick="location.href='../top'">top</button>
-			<form th:action="@{/logout}" method="post">
-				<input type="submit" value="logout" class="logout_btn">
-			</form>
-		</div>
+		<div th:replace="common/header::header"></div>
 		<h2>テスト結果</h2>
 		<p>[[${userName}]]さん</p>
 		<p>[[${queCnt}]]問中[[${correctQueCnt}]]問正解です。</p>

--- a/src/main/resources/templates/test.html
+++ b/src/main/resources/templates/test.html
@@ -6,12 +6,7 @@
 		<link rel="stylesheet" media="all" th:href="@{/css/style.css}"/>
 	</head>
 	<body>
-		<div class="btn_area">
-			<button onclick="location.href='./top'">top</button>
-			<form th:action="@{/logout}" method="post">
-				<input type="submit" value="logout" class="logout_btn">
-			</form>
-		</div>
+		<div th:replace="common/header::header"></div>
 		<!-- 問題が登録されていない場合  -->
 		<th:block th:if="${queList.isEmpty()}">
 			<p>問題が登録されていません</p>

--- a/src/main/resources/templates/user_delete_confirm.html
+++ b/src/main/resources/templates/user_delete_confirm.html
@@ -1,17 +1,12 @@
 <!DOCTYPE html>
 <html>
-<head>
-<meta charset="UTF-8">
-<title>user_delete_confirm</title>
-<link rel="stylesheet" media="all" th:href="@{/css/style.css}"/>
-</head>
+	<head>
+		<meta charset="UTF-8">
+		<title>user_delete_confirm</title>
+		<link rel="stylesheet" media="all" th:href="@{/css/style.css}"/>
+	</head>
 	<body>
-		<div class="btn_area">
-			<button onclick="location.href='/top'">top</button>
-			<form th:action="@{/logout}" method="post">
-				<input type="submit" value="logout" class="logout_btn">
-			</form>
-		</div>
+		<div th:replace="common/header::header"></div>
 		<!-- formタグで/user/delete/{id}/completeにpostで送信する  -->
 		<form class="user_form_area" th:action="@{/user/delete/{id}/complete(id=${userId})}" method="post">
 			<div  class="user_form">

--- a/src/main/resources/templates/user_edit.html
+++ b/src/main/resources/templates/user_edit.html
@@ -1,18 +1,13 @@
 <!DOCTYPE html>
 <html>
-<head>
-<meta charset="UTF-8">
-<title>user_edit</title>
-<link rel="stylesheet" media="all" th:href="@{/css/style.css}"/>
-<script type="text/javascript" th:src="@{/js/check_user_validation.js}"></script>
-</head>
+	<head>
+		<meta charset="UTF-8">
+		<title>user_edit</title>
+		<link rel="stylesheet" media="all" th:href="@{/css/style.css}"/>
+		<script type="text/javascript" th:src="@{/js/check_user_validation.js}"></script>
+	</head>
 	<body>
-		<div class="btn_area">
-			<button onclick="location.href='/top'">top</button>
-			<form th:action="@{/logout}" method="post">
-				<input type="submit" value="logout" class="logout_btn">
-			</form>
-		</div>
+		<div th:replace="common/header::header"></div>
 		<!-- formタグで入力されたデータを/user/edit/{id}/confirmにpostで送信する（送信する前にjsでバリデーションチェックする）  -->
 		<form class="user_form_area" th:action="@{/user/edit/{id}/confirm(id=${userId})}" method="post" onsubmit="return checkValidation()">
 			<div  class="user_form">

--- a/src/main/resources/templates/user_edit_confirm.html
+++ b/src/main/resources/templates/user_edit_confirm.html
@@ -1,17 +1,12 @@
 <!DOCTYPE html>
 <html>
-<head>
-<meta charset="UTF-8">
-<title>user_edit_confirm</title>
-<link rel="stylesheet" media="all" th:href="@{/css/style.css}"/>
-</head>
+	<head>
+		<meta charset="UTF-8">
+		<title>user_edit_confirm</title>
+		<link rel="stylesheet" media="all" th:href="@{/css/style.css}"/>
+	</head>
 	<body>
-		<div class="btn_area">
-			<button onclick="location.href='/top'">top</button>
-			<form th:action="@{/logout}" method="post">
-				<input type="submit" value="logout" class="logout_btn">
-			</form>
-		</div>
+		<div th:replace="common/header::header"></div>
 		<!-- formタグで以下のデータを/user/edit/{id}/completeにpostで送信する  -->
 		<form class="user_form_area" th:action="@{/user/edit/{id}/complete(id=${userId})}" method="post">
 			<div  class="user_form">

--- a/src/main/resources/templates/user_edit_confirm.html
+++ b/src/main/resources/templates/user_edit_confirm.html
@@ -14,6 +14,10 @@
 		</div>
 		<!-- formタグで以下のデータを/user/edit/{id}/completeにpostで送信する  -->
 		<form class="user_form_area" th:action="@{/user/edit/{id}/complete(id=${userId})}" method="post">
+			<div  class="user_form">
+				<label>ID: </label>
+				<p th:text="${userId}"></p>
+			</div>
 			<div class="user_form">
 				<label>ユーザー名: </label>
 				<p th:text="${userName}"></p>

--- a/src/main/resources/templates/user_lists.html
+++ b/src/main/resources/templates/user_lists.html
@@ -1,17 +1,12 @@
 <!DOCTYPE html>
 <html>
-<head>
-<meta charset="UTF-8">
-<title>user_lists</title>
-<link rel="stylesheet" media="all" th:href="@{/css/style.css}"/>
-</head>
+	<head>
+		<meta charset="UTF-8">
+		<title>user_lists</title>
+		<link rel="stylesheet" media="all" th:href="@{/css/style.css}"/>
+	</head>
 	<body>
-		<div class="btn_area">
-			<button onclick="location.href='../top'">top</button>
-			<form th:action="@{/logout}" method="post">
-				<input type="submit" value="logout" class="logout_btn">
-			</form>
-		</div>
+		<div th:replace="common/header::header"></div>
 		<button class="user_new_btn" onclick="location.href='./register'" >新規登録</button>
 		<table class="user_table">
 			<tr>

--- a/src/main/resources/templates/user_register.html
+++ b/src/main/resources/templates/user_register.html
@@ -1,18 +1,13 @@
 <!DOCTYPE html>
 <html>
-<head>
-<meta charset="UTF-8">
-<title>user_register</title>
-<link rel="stylesheet" media="all" th:href="@{/css/style.css}"/>
-<script type="text/javascript" th:src="@{/js/check_user_validation.js}"></script>
-</head>
+	<head>
+		<meta charset="UTF-8">
+		<title>user_register</title>
+		<link rel="stylesheet" media="all" th:href="@{/css/style.css}"/>
+		<script type="text/javascript" th:src="@{/js/check_user_validation.js}"></script>
+	</head>
 	<body>
-		<div class="btn_area">
-			<button onclick="location.href='/top'">top</button>
-			<form th:action="@{/logout}" method="post">
-				<input type="submit" value="logout" class="logout_btn">
-			</form>
-		</div>
+		<div th:replace="common/header::header"></div>
 		<!-- formタグで入力されたデータを/user/register/confirmにpostで送信する（送信する前にjsでバリデーションチェックする）  -->
 		<form class="user_form_area" th:action="@{/user/register/confirm}" method="post" onsubmit="return checkValidation()">
 			<div  class="user_form">

--- a/src/main/resources/templates/user_register_confirm.html
+++ b/src/main/resources/templates/user_register_confirm.html
@@ -1,17 +1,12 @@
 <!DOCTYPE html>
 <html>
-<head>
-<meta charset="UTF-8">
-<title>user_register_confirm</title>
-<link rel="stylesheet" media="all" th:href="@{/css/style.css}"/>
-</head>
+	<head>
+		<meta charset="UTF-8">
+		<title>user_register_confirm</title>
+		<link rel="stylesheet" media="all" th:href="@{/css/style.css}"/>
+	</head>
 	<body>
-		<div class="btn_area">
-			<button onclick="location.href='/top'">top</button>
-			<form th:action="@{/logout}" method="post">
-				<input type="submit" value="logout" class="logout_btn">
-			</form>
-		</div>
+		<div th:replace="common/header::header"></div>
 		<!-- formタグで入力されたデータを/user/register/completeにpostで送信する  -->
 		<form class="user_form_area" th:action="@{/user/register/complete}" method="post">
 			<div class="user_form">

--- a/src/test/java/com/example/demo/dbunit/sampleData.xml
+++ b/src/test/java/com/example/demo/dbunit/sampleData.xml
@@ -10,4 +10,8 @@
     <histories id="1" user_id="1" point="10" created_at="2024-05-20 12:00:00" />
     <histories id="2" user_id="1" point="20" created_at="2024-05-20 11:00:00" />
     <histories id="3" user_id="2" point="30" created_at="2024-05-20 14:00:00" />
+    <users id="1" name="testuser1" password="JzloXih8I+6oLnm51tL6aw==" admin_flag="1" />
+    <users id="2" name="testuser2" password="0VbhPuCCJrYqP2SDurhbZw==" admin_flag="0" />
+    <users id="3" name="testuser3" password="w1SKccXvnocnhaRrwjADpQ==" admin_flag="1" />
+    <users id="4" name="testuser4" password="w1SKccXvnocnhaRrwjADpQ==" admin_flag="1" deleted_at="2024-05-27 18:43:05" />
 </dataset>

--- a/src/test/java/com/example/demo/service/AnswerServiceTest.java
+++ b/src/test/java/com/example/demo/service/AnswerServiceTest.java
@@ -83,7 +83,6 @@ class AnswerServiceTest {
 		assertThat(ansList2.size() - ansList1.size(), is(1));
 		//最新の答えが、登録した答えと一致しているか確認
 		assertThat(ansList2.get(3).getAnswer(), is(answer));
-		
 	}
 	
 	@Test

--- a/src/test/java/com/example/demo/service/HistoryServiceTest.java
+++ b/src/test/java/com/example/demo/service/HistoryServiceTest.java
@@ -71,4 +71,16 @@ class HistoryServiceTest {
 		//user_id = 1と紐づく最新のデータが、登録したデータと一致することを確認
 		assertThat(hisList2.get(2).getPoint(), is(50));
 	}
+	
+	@Test
+	@DatabaseSetup("../dbunit/sampleData.xml")
+	@DisplayName("deleteメソッドに、登録されているuser_idを渡すと、履歴が削除できること")
+	public void deleteUserWhenRegisterUserId() throws Exception {
+		//登録されているuser_idを渡し、履歴を削除
+		historyService.delete(1);
+		//user_id = 1と一致するデータを取得
+		ArrayList<History> hisList = historyService.findByUserId(1);
+		//履歴が取得できていないことを確認
+		assertTrue(hisList.isEmpty());
+	}
 }

--- a/src/test/java/com/example/demo/service/QuestionServiceTest.java
+++ b/src/test/java/com/example/demo/service/QuestionServiceTest.java
@@ -100,7 +100,7 @@ class QuestionServiceTest {
 		assertThat(queList1.size() - queList2.size(), is(1));
 		//id = 1に紐づくデータがDBに存在しないことを確認
 		for(Question que : queList2) { 
-			assertThat(queList2.get(0).getId(), is(not(1)));
+			assertThat(que.getId(), is(not(1)));
 		}
 	}
 	

--- a/src/test/java/com/example/demo/service/UserServiceTest.java
+++ b/src/test/java/com/example/demo/service/UserServiceTest.java
@@ -4,6 +4,8 @@ import static org.hamcrest.MatcherAssert.*;
 import static org.hamcrest.Matchers.*;
 import static org.junit.jupiter.api.Assertions.*;
 
+import java.util.ArrayList;
+
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -12,13 +14,24 @@ import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.security.core.userdetails.UsernameNotFoundException;
 import org.springframework.test.context.TestExecutionListeners;
 import org.springframework.test.context.support.DependencyInjectionTestExecutionListener;
+import org.springframework.test.context.support.DirtiesContextTestExecutionListener;
+import org.springframework.test.context.transaction.TransactionalTestExecutionListener;
 
 import com.example.demo.model.User;
+import com.example.demo.security.PasswordEncrypter;
+import com.github.springtestdbunit.DbUnitTestExecutionListener;
+import com.github.springtestdbunit.annotation.DatabaseSetup;
+
+import jakarta.transaction.Transactional;
 
 @SpringBootTest
 @TestExecutionListeners({
-    DependencyInjectionTestExecutionListener.class
+    DependencyInjectionTestExecutionListener.class,
+    DirtiesContextTestExecutionListener.class,
+    TransactionalTestExecutionListener.class,
+    DbUnitTestExecutionListener.class
 })
+@Transactional
 class UserServiceTest {
 	
 	//以下のクラスをインスタンス化
@@ -26,6 +39,7 @@ class UserServiceTest {
 	private UserService userService;
 	
 	@Test
+	@DatabaseSetup("../dbunit/sampleData.xml")
 	@DisplayName("findByIdメソッドに、登録されていないuserIdを引数として渡した場合、ユーザーが取得できないこと")
 	public void notGetUserWhenNotRegisterUserId() throws Exception {
 		//登録されていないidを渡して、ユーザーを取得しようとする
@@ -35,16 +49,18 @@ class UserServiceTest {
 	}
 
 	@Test
+	@DatabaseSetup("../dbunit/sampleData.xml")
 	@DisplayName("findByIdメソッドに、登録されているuserIdを引数として渡した場合、ユーザーを取得できること")
 	public void getUserWhenRegisterUserId() throws Exception {
 		//登録されているidを渡して、ユーザーを取得
 		User user = userService.findById(1);
 		//ユーザーが取得できることを確認
 		assertThat(user.getId(), is(1));
-		assertThat(user.getName(), is("testuser"));
+		assertThat(user.getName(), is("testuser1"));
 	}
 	
 	@Test
+	@DatabaseSetup("../dbunit/sampleData.xml")
 	@DisplayName("loadUserByUsernameメソッドに、登録されていないuserIdを渡した場合、UserDetailsが取得できないこと")
 	public void  notGetUserDetailsWhenNotRegisterUserId() throws Exception{
 		UserDetails user = null;
@@ -61,6 +77,7 @@ class UserServiceTest {
 	}
 	
 	@Test
+	@DatabaseSetup("../dbunit/sampleData.xml")
 	@DisplayName("loadUserByUsernameメソッドに、文字列を渡した場合、UserDetailsが取得できないこと")
 	public void notGetUserDetailsWhentext() throws Exception{
 		UserDetails user = null;
@@ -77,6 +94,7 @@ class UserServiceTest {
 	}
 	
 	@Test
+	@DatabaseSetup("../dbunit/sampleData.xml")
 	@DisplayName("loadUserByUsernameメソッドに、小数を渡した場合、UserDetailsが取得できないこと")
 	public void notGetUserDetailsWhenDecimal() throws Exception{
 		UserDetails user = null;
@@ -93,6 +111,7 @@ class UserServiceTest {
 	}
 	
 	@Test
+	@DatabaseSetup("../dbunit/sampleData.xml")
 	@DisplayName("loadUserByUsernameメソッドに、負の数を渡した場合、UserDetailsが取得できないこと")
 	public void notGetUserDetailsWhenNegativeNumber() throws Exception{
 		UserDetails user = null;
@@ -109,6 +128,7 @@ class UserServiceTest {
 	}
 	
 	@Test
+	@DatabaseSetup("../dbunit/sampleData.xml")
 	@DisplayName("loadUserByUsernameメソッドに、登録されているuserIdを渡した場合、UserDetailsが取得できること")
 	public void getUserDetailsWhenRegisterUserId() throws Exception {
 		UserDetails user = null;
@@ -121,6 +141,116 @@ class UserServiceTest {
 			//ユーザーが取得できることを確認
 			assertThat(user.getUsername(), is("1"));
 		}
+	}
+	
+	@Test
+	@DatabaseSetup("../dbunit/sampleData.xml")
+	@DatabaseSetup("../dbunit/sampleData.xml")
+	@DisplayName("findAllメソッドで、削除されていないユーザーが全件取得できること")
+	public void getUserAll() throws Exception {
+		//ユーザーを全件取得
+		ArrayList<User> userList = userService.findAll();
+		//DBに登録されているデータと、取得したデータが一致しているか確認
+		assertThat(userList.get(0).getName(), is("testuser1"));
+		assertThat(userList.get(1).getName(), is("testuser2"));
+		assertThat(userList.get(2).getName(), is("testuser3"));
+		//取得したデータに、削除されているユーザーが含まれていないことを確認
+		for(User user : userList) { 
+			assertThat(user.getName(), is(not("testuser4")));
+		}
+	}
+	
+	@Test
+	@DatabaseSetup("../dbunit/sampleData.xml")
+	@DisplayName("registerメソッドで、ユーザーが登録できること")
+	public void registerUser() throws Exception {
+		//ユーザーを全件取得
+		ArrayList<User> userList1 = userService.findAll();
+		//ユーザー名、パスワード、管理者権限を渡し、問題を登録
+		String userName = "testuser";
+		String password = "testtest";
+		int adminFlag = 1;
+		userService.register(userName, password, adminFlag);
+		//ユーザーを全件取得
+		ArrayList<User> userList2 = userService.findAll();
+		//パスワードをデコードするためインスタンス化する
+		PasswordEncrypter passEncrypter = new PasswordEncrypter();
+		//DBに登録されている答えが1件増えたことを確認
+		assertThat(userList2.size() - userList1.size(), is(1));
+		//DBの最新のデータが、登録したデータと一致しているか確認
+		assertThat(userList2.get(3).getName(), is(userName));
+		assertThat(passEncrypter.decrypt(userList2.get(3).getPassword()), is(password));
+		assertThat(userList2.get(3).getAdmin_flag(), is(adminFlag));
+	}
+	
+	@Test
+	@DatabaseSetup("../dbunit/sampleData.xml")
+	@DisplayName("updateメソッドに、登録されているidを渡すと、ユーザー情報が更新できること")
+	public void updateUserWhenRegisterId() throws Exception {
+		//登録されているidと、パスワード、管理者権限を渡し、ユーザー情報を更新
+		String password = "testtest5";
+		int adminFlag = 0;
+		userService.update(1, password, adminFlag);
+		//ユーザーを全件取得
+		ArrayList<User> userList = userService.findAll();
+		//パスワードをデコードするためインスタンス化する
+		PasswordEncrypter passEncrypter = new PasswordEncrypter();
+		//id = 1 に紐づくユーザー情報が、更新されていることを確認
+		assertThat(passEncrypter.decrypt(userList.get(0).getPassword()), is(password));
+		assertThat(userList.get(0).getAdmin_flag(), is(adminFlag));
+	}
+	
+	@Test
+	@DatabaseSetup("../dbunit/sampleData.xml")
+	@DisplayName("updateメソッドに、登録されていないidを渡すと、ユーザー情報が更新できないこと")
+	public void notUpdateUserWhenNotRegisterId() throws Exception {
+		//登録されていないidと、パスワード、管理者権限を渡し、ユーザー情報を更新
+		String password = "testtest5";
+		int adminFlag = 0;
+		userService.update(10, password, adminFlag);
+		//ユーザーを全件取得
+		ArrayList<User> userList = userService.findAll();
+		//パスワードをデコードするためインスタンス化する
+		PasswordEncrypter passEncrypter = new PasswordEncrypter();
+		//取得したデータからpasswordだけ取り出し、リスト化
+		ArrayList<String> passwords = new ArrayList<>();
+		for(int i = 0; i < userList.size(); i++) {
+			passwords.add(passEncrypter.decrypt(userList.get(i).getPassword()));
+		}
+		//リストに、更新した内容が含まれていないことを確認
+		assertThat(passwords, hasItems(not("testtest5")));
+	}
+	
+	@Test
+	@DatabaseSetup("../dbunit/sampleData.xml")
+	@DisplayName("deleteメソッドに、登録されているidを渡すと、ユーザーが削除できること")
+	public void deleteUserWhenRegisterId() throws Exception {
+		//ユーザーを全件取得
+		ArrayList<User> userList1 = userService.findAll();
+		//登録されているidを渡し、問題を削除
+		userService.delete(1);
+		//問題を全件取得
+		ArrayList<User> userList2 = userService.findAll();
+		//取得したデータが1件減ったことを確認
+		assertThat(userList1.size() - userList2.size(), is(1));
+		//id = 1に紐づくデータが存在しないことを確認
+		for(User user : userList2) { 
+			assertThat(user.getId(), is(not(1)));
+		}
+	}
+	
+	@Test
+	@DatabaseSetup("../dbunit/sampleData.xml")
+	@DisplayName("deleteメソッドに、登録されていないidを渡すと、ユーザーが削除できないこと")
+	public void notDeleteUserWhenNotRegisterId() throws Exception {
+		//ユーザーを全件取得
+		ArrayList<User> userList1 = userService.findAll();
+		//登録されていないidを渡し、問題を削除
+		userService.delete(10);
+		//問題を全件取得
+		ArrayList<User> userList2 = userService.findAll();
+		//取得したデータが減っていないことを確認
+		assertThat(userList1.size() - userList2.size(), is(0));
 	}
 
 }


### PR DESCRIPTION
<単体テスト>
・UserServiceTest に ユーザーの全件取得、登録、編集、削除機能に関するテストを追加
・HistoryServiceTest に履歴の削除に関するテストを追加

<その他>
・ユーザー編集確認画面にユーザーIDを表示させるようにする
・ユーザー編集処理において、ログインしているユーザーが自身の管理者権限を外した場合の処理を追加
・UserController のpostLogoutメソッドを削除
・権限がないページにアクセスした場合や、存在しないページにアクセスした場合のエラー画面を作成し、設定
・管理者権限しかアクセスできないページに、問題一覧画面や問題登録画面、問題削除確認画面、問題編集画面を追加
・各ページのtopボタンやlogoutボタンの表示をパーシャルにする